### PR TITLE
Fix the minimal number at AP

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    br_documents (0.2.4)
+    br_documents (0.2.5)
       activemodel (>= 4.0.0)
       i18n (>= 0.6.5)
 

--- a/lib/br_documents/ie/ap.rb
+++ b/lib/br_documents/ie/ap.rb
@@ -22,7 +22,7 @@ module BrDocuments
       end
 
       def valid_check_digit?
-        return false if @number.to_i.zero?
+        return false if number_to_calculate_digits < 3_000_001
 
         weight = [9, 8, 7, 6, 5, 4, 3, 2]
         detect_range_digits
@@ -33,7 +33,7 @@ module BrDocuments
 
       # rubocop:disable Metrics/MethodLength
       def detect_range_digits
-        number = @number[0, 8].to_i
+        number = number_to_calculate_digits
 
         if number >= 3_000_001 && number <= 3_017_000
           @p = 5
@@ -47,6 +47,10 @@ module BrDocuments
         end
       end
       # rubocop:enable Metrics/MethodLength
+
+      def number_to_calculate_digits
+        @number[0, 8].to_i
+      end
 
       def generate_check_digit(values, weights)
         sum = reduce_weights(values, weights)

--- a/lib/br_documents/version.rb
+++ b/lib/br_documents/version.rb
@@ -1,3 +1,3 @@
 module BrDocuments
-  VERSION = '0.2.4'.freeze
+  VERSION = '0.2.5'.freeze
 end

--- a/spec/br_documents/ie/ap_spec.rb
+++ b/spec/br_documents/ie/ap_spec.rb
@@ -18,22 +18,29 @@ RSpec.describe BrDocuments::IE::AP do
     end
 
     it 'is invalid with invalid check number' do
-      ['030123456', '030182454', '000000000'].each do |number|
+      ['030123456', '030182454'].each do |number|
+        ie = described_class.new(number)
+        expect(ie).not_to be_valid
+      end
+    end
+
+    it 'is invalid if the number is less than 3_000_001' do
+      ['030000000', '000000000'].each do |number|
         ie = described_class.new(number)
         expect(ie).not_to be_valid
       end
     end
 
     it 'is valid with valid number' do
-      first_range_number = '030123459'
+      first_range_number = '030000012'
       ie = described_class.new(first_range_number)
       expect(ie).to be_valid
 
-      second_range_number = '030183458'
+      second_range_number = '030170011'
       ie = described_class.new(second_range_number)
       expect(ie).to be_valid
 
-      third_range_number = '030192455'
+      third_range_number = '030190231'
       ie = described_class.new(third_range_number)
       expect(ie).to be_valid
     end


### PR DESCRIPTION
Segue #97.

Ao fazer testes manuais, foi percebido essa situação.

### Erro ao tentar um número menor que `030000012`
```shell
  ↳ app/services/people/save.rb:10:in `call'
  TRANSACTION (2.7ms)  ROLLBACK
  ↳ app/services/people/save.rb:10:in `call'
Completed 500 Internal Server Error in 67ms (ActiveRecord: 26.8ms | Allocations: 14771)



TypeError (nil can't be coerced into Integer):

app/services/people/save.rb:10:in `call'
app/services/application_service.rb:3:in `call'
app/controllers/api/v1/people_controller.rb:40:in `update'
```